### PR TITLE
fix arch for 64bit windows in maven profile activation

### DIFF
--- a/hibersap-parent/pom.xml
+++ b/hibersap-parent/pom.xml
@@ -141,7 +141,7 @@
             <activation>
                 <os>
                     <family>windows</family>
-                    <arch>x86_64</arch>
+                    <arch>amd64</arch>
                 </os>
             </activation>
             <properties>


### PR DESCRIPTION
The Maven enforder-plugin shows on my 64bit windows another information for the architecture than currently configured in the parent pom.
I fixed the activation accordingly to the information display from the enforcer plugin:
mvn enforcer:display-info shows "OS Info: Arch: amd64 Family: windows"

Best Regards
René
