### PR TITLE
hibersap/hibersap#9

### DIFF
--- a/hibersap-core/src/main/java/org/hibersap/configuration/Configuration.java
+++ b/hibersap-core/src/main/java/org/hibersap/configuration/Configuration.java
@@ -140,10 +140,25 @@ public abstract class Configuration {
         return data.getSessionManagerConfig();
     }
 
+    /**
+     * Load hibersap.xml file from default location (see Environment.HIBERSAP_XML_FILE) or from -D Parameter (see Environment.HIBERSAP_XML_FILE)
+     * @return The hibersap config
+     */
     private HibersapConfig readHibersapConfig() {
-        LOG.debug("Reading HibersapConfig from configuration file");
+
+        String configFile;
+        try {
+            // Get path to xml from system property or as fallback use default location
+            // see: https://github.com/hibersap/hibersap/issues/9
+            configFile = System.getProperty(Environment.HIBERSAP_XML_FILE_PARAMETER, Environment.HIBERSAP_XML_FILE);
+        } catch (NullPointerException e) {
+            configFile = Environment.HIBERSAP_XML_FILE;
+        } catch (IllegalArgumentException e) {
+            configFile = Environment.HIBERSAP_XML_FILE;
+        }
+        LOG.debug("Reading HibersapConfig from configuration file: '" + configFile + "'");
 
         final HibersapJaxbXmlParser parser = new HibersapJaxbXmlParser();
-        return parser.parseResource(Environment.HIBERSAP_XML_FILE);
+        return parser.parseResource(configFile);
     }
 }

--- a/hibersap-core/src/main/java/org/hibersap/configuration/Environment.java
+++ b/hibersap-core/src/main/java/org/hibersap/configuration/Environment.java
@@ -28,6 +28,9 @@ import org.hibersap.HibersapException;
 */
 public final class Environment {
 
+    // Name of the -D parameter to set another location for hibersap.xml file
+    // see: https://github.com/hibersap/hibersap/issues/9
+    public static final String HIBERSAP_XML_FILE_PARAMETER = "hibersap.xmlFile";
     public static final String HIBERSAP_XML_FILE = "/META-INF/hibersap.xml";
     private static final String HIBERSAP_VERSION_FILE = "hibersap-version.properties";
     private static final String HIBERSAP_VERSION_PROPERTY_KEY = "hibersap-version";

--- a/hibersap-core/src/main/java/org/hibersap/configuration/xml/HibersapJaxbXmlParser.java
+++ b/hibersap-core/src/main/java/org/hibersap/configuration/xml/HibersapJaxbXmlParser.java
@@ -18,8 +18,10 @@
 
 package org.hibersap.configuration.xml;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -111,6 +113,20 @@ public class HibersapJaxbXmlParser {
         URL resource = Thread.currentThread().getContextClassLoader().getResource(resourceName);
         if (resource == null) {
             resource = getClass().getResource(resourceName);
+        }
+        // load from -D parameter, can be outside of the classpath!
+        // see: https://github.com/hibersap/hibersap/issues/9
+        if(resource == null) {
+            try {
+                File configFile = new File(resourceName);
+                resource = configFile.toURI().toURL();
+            } catch (final MalformedURLException e) {
+                throw new InternalHiberSapException("Cannot load resource " + resourceName, e);
+            } catch (final NullPointerException e) {
+                throw new InternalHiberSapException("Cannot load resource " + resourceName, e);
+            } catch (final IllegalArgumentException e) {
+                throw new InternalHiberSapException("Cannot load resource " + resourceName, e);
+            }
         }
         if (resource == null) {
             throw new InternalHiberSapException("Cannot locate resource " + resourceName);


### PR DESCRIPTION
Implemented the enhancement request hibersap/hibersap#9 as we also needed this in our project. 

I added a system parameter "-Dhibersap.xmlFile=/path/to/hibersap.xml". If this parameter is set hibersap will now try to get the hibersap.xml from this location. If it is not set it will use the old mechanics.

We need this parameter to use supply the hibersap.xml files in our kubernetes environment from hashcorp vault.